### PR TITLE
Create download-iisbuilder.ps1

### DIFF
--- a/download-iisbuilder.ps1
+++ b/download-iisbuilder.ps1
@@ -1,0 +1,2 @@
+(new-object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mattou07/iis-builder/master/IIS-Builder.ps1','IIS-Builder.ps1')
+(new-object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mattou07/iis-builder/master/iis-config.json','iis-config.json')


### PR DESCRIPTION
This PR is to add a new file called download-iisbuilder.ps1 which has the 2 commands to download the latest versions of the ps1 and config files.

Then you can just use this file every time you want to use iis-builder on a new project. And it still downloads the latest files.

I use it this way all the time on my projects. 

It would be good to have this file in the repo for people to download and run, but it's up to you. I won't be offended if you don't want to merge it in.

