### PR TITLE
Handle space in Path when restarting

### DIFF
--- a/IIS-Builder.ps1
+++ b/IIS-Builder.ps1
@@ -22,7 +22,7 @@ if((![string]::IsNullOrWhiteSpace($path))) {
 }
 
 if ((Test-Path "$dir\iis-config.json") -eq $false){
-    Write-Host "Could not find iis-config.json in $dir"
+    Write-Host "Could not find iis-config.json in '$dir'"
     exit
 }
 


### PR DESCRIPTION
Wrap $dir arg in ' so if there is a space it doesn't error