### PR TITLE
Set AppPool to "No Managed Code" when empty string used in config value: IIS-App-Pool-Dot-Net-Version

### DIFF
--- a/IIS-Builder.ps1
+++ b/IIS-Builder.ps1
@@ -126,7 +126,8 @@ function getSiteStatus($iis){
 function createAppPool($appPoolName, $runtimeVersion){
     #create the app pool
     $appPool = New-WebAppPool $appPoolName
-    $appPool | Set-ItemProperty -Name "managedRuntimeVersion" -Value $runtimeVersion
+    $appPool.managedRuntimeVersion = $runtimeVersion
+    $appPool | Set-Item
 }
 
 function createSite($iis){


### PR DESCRIPTION
When attempting to set the runtime version to "No Managed Code" by setting the "IIS-App-Pool-Dot-Net-Version" in the iis-config.json to an empty string, the original code defaulted to setting the .NET CLR Version to "v4.0", but this change (which looks like it shouldn't behave any differently !) will set it to "No Managed Code".