### PR TITLE
Applied fix for spaces in paths

### DIFF
--- a/IIS-Builder.ps1
+++ b/IIS-Builder.ps1
@@ -2,10 +2,11 @@ param ([string]$path)
 
 $script = $myinvocation.mycommand.definition
 $dir = Split-Path $MyInvocation.MyCommand.Path
-Write-Host "Script location $script"
-Write-Host "Script started in $dir"
+Write-Host 'Script location '($script)
+Write-Host 'Script started in '($dir)
 
 if((![string]::IsNullOrWhiteSpace($path))) {
+    Write-Host $($path)
     if((Test-Path $path)){
         if([System.IO.Path]::IsPathRooted($path)){
             $dir = $path
@@ -16,13 +17,13 @@ if((![string]::IsNullOrWhiteSpace($path))) {
         Write-Host "Path has been supplied passing in: $dir as working directory"
     }
     else {
-        Write-Host "Unable to locate $path please provide a valid path"
+        Write-Host "Unable to locate "($path)" please provide a valid path"
         exit
     }
 }
 
 if ((Test-Path "$dir\iis-config.json") -eq $false){
-    Write-Host "Could not find iis-config.json in $dir"
+    Write-Host "Could not find iis-config.json in "($dir)
     exit
 }
 
@@ -30,7 +31,7 @@ if ((Test-Path "$dir\iis-config.json") -eq $false){
 If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
 {
     Write-Host "Script has been opened without Admin permissions, attempting to restart as admin"
-    $arguments = "-noexit & '" + $script + "'","-path $dir"
+    $arguments = "-noexit & '" + $script + "'","-path " + "'"+$dir+"'"
     Start-Process powershell -Verb runAs -ArgumentList $arguments
     Break
 }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ Ensure **Use Output window** is **enabled** this will allow you to see the outpu
 
 To prevent IIS Builder popping up an Elevated Powershell Window, open Visual Studio as Admin. However this is not necessary.
 
+### Setup a Powershell Alias
+
+If you love using the terminal you could setup a Powershell Alias. Where all you need to do is navigate to your folder via Powershell and type **IISBuilder** or whatever alias/shortcut you prefer. This then runs IIS-Builder.ps1 in your current working directory:
+
+![Running IISBuilder as a Powershell Alias](https://i.imgur.com/jN0SiDp.png)
+
+To set this up you need to identify where your Powershell user profile lives, by typing:  `echo $profile` 
+
+This will reveal where Powershell thinks the User profile lives. Usually its **~Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1**. Adding any code within this file will be executed on each Powershell session for your User. When you set an Alias its forgotten when you close the Powershell session. By setting our alias in our profile, Powershell will create the alias each time we start a Powershell Session 
+
+Navigate to your profile location and open the **Microsoft.PowerShell_profile.ps1** file. If it doesn't exist **create** it. Then add the following code to setup the alias:
+
+```powershell
+Function IISBuilderFunc {C:\your-path-to-iisbuilder\IIS-Builder.ps1 -Path $(Get-Location)}
+
+Set-Alias -Name IISBuilder -Value IISBuilderFunc
+```
+
+Make sure to provide the correct path to where the IIS-Builder.ps1 file lives. Feel free to change the Alias name to whatever you wish or even rename the function. These two lines tell Powershell to create an Alias called IISBuilder that triggers the function IISBuilderFunc above. The function just calls the IISBuilder script file and passes in the current location of the terminal as the **-Path** parameter allowing you to run the alias anywhere.
+
+Save the file and re-open a Powershell Terminal, then navigate to your web root and type IISBuilder.
+
 ## Additional tips
 
 ### Attaching script to Visual Studio Post build event


### PR DESCRIPTION
The script should now properly pass on the path parameter (even if it contains spaces) when the script is invoked again to elevate the script into a new process.

Requires some more testing before I merge this into the default branch